### PR TITLE
Fixed dataset link

### DIFF
--- a/Chapter01/cnn_chapter.ipynb
+++ b/Chapter01/cnn_chapter.ipynb
@@ -19,7 +19,7 @@
     "# http://benchmark.ini.rub.de/?section=gtsrb&subsection=dataset\n",
     "# \n",
     "# On linux systems:\n",
-    "#! wget -q http://benchmark.ini.rub.de/Dataset/GTSRB_Final_Training_Images.zip\n",
+    "#! wget -q https://sid.erda.dk/public/archives/daaeac0d7ce1152aea9b61d9f1e19370/GTSRB_Final_Training_Images.zip\n",
     "#! unzip -q GTSRB_Final_Training_Images.zip"
    ]
   },


### PR DESCRIPTION
The GTSRB dataset's [link](https://benchmark.ini.rub.de/Dataset/GTSRB_Final_Training_Images.zip) is not working (URL not found). So added this link [GTSRB](https://sid.erda.dk/public/archives/daaeac0d7ce1152aea9b61d9f1e19370/GTSRB_Final_Training_Images.zip)